### PR TITLE
feat: theme installation for TorBrowser support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,12 @@ GITHUB_BRANCH_NAME="master"
 GITHUB_PROJECT_NAME="Zonnev/elementaryos-firefox-theme"
 GITHUB_URL="https://github.com"
 GITHUB_URL_RAW="https://raw.githubusercontent.com"
+LOCALE="$(echo ${LANG} | cut -d '.' -f 1 | tr '_' '-')"
+
+function getFlatpakProcessIdCommand {
+  local FLATPAK_ID="${1}"
+  echo "flatpak ps --columns=pid,application | grep \"${FLATPAK_ID}\" | cut -f1"
+}
 
 declare -a BROWSERS
 declare -A BROWSERS_PROCESS_ID
@@ -27,20 +33,33 @@ BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "firefox-trunk" || exit 0'
 BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.mozilla/firefox-trunk"
 
+FLATPAK_ID="org.mozilla.firefox"
 BROWSER="🦊 Firefox (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
-BROWSERS_PROCESS_ID["${BROWSER}"]='flatpak ps --columns=pid,application | grep "org.mozilla.firefox" | cut -f1'
-BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.var/app/org.mozilla.firefox/.mozilla/firefox"
+BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
+BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.mozilla/firefox"
 
 BROWSER="🐺 Librewolf";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "librewolf" || exit 0'
 BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.librewolf"
 
+FLATPAK_ID="io.gitlab.librewolf-community"
 BROWSER="🐺 Librewolf (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
-BROWSERS_PROCESS_ID["${BROWSER}"]='flatpak ps --columns=pid,application | grep "io.gitlab.librewolf-community" | cut -f1'
-BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.var/app/io.gitlab.librewolf-community/.librewolf"
+BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
+BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.librewolf"
+
+BROWSER="🧅 Tor Browser";
+BROWSERS+=("${BROWSER}");
+BROWSERS_PROCESS_ID["${BROWSER}"]="pidof \"${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_${LOCALE}/Browser/firefox.real\" || exit 0"
+BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_${LOCALE}/Browser/TorBrowser/Data/Browser"
+
+FLATPAK_ID="com.github.micahflee.torbrowser-launcher"
+BROWSER="🧅 Tor Browser (📦 Flatpak)";
+BROWSERS+=("${BROWSER}");
+BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
+BROWSERS_PROFILES_ROOT["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/data/torbrowser/tbb/x86_64/tor-browser_${LOCALE}/Browser/TorBrowser/Data/Browser"
 
 declare -a LAYOUTS
 declare -A LAYOUTS_PATHS

--- a/readme.md
+++ b/readme.md
@@ -9,12 +9,15 @@ Credits to [Harvey Cabaguio](https://github.com/harveycabaguio/firefox-elementar
 
 For now theme installation is supported for:
 
-1. 🦊 Firefox installed with apt package manager.
+1. [🦊 Firefox](https://www.mozilla.org/en-US/firefox/new/) installed with apt package manager.
    To install it run command `sudo apt install firefox` with your Terminal.
-2. 🦊 Firefox Nightly installed with apt package manager.
+2. [🦊 Firefox Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly)
+   installed with apt package manager.
 3. [🦊 Firefox 📦 Flatpak version](https://flathub.org/apps/details/org.mozilla.firefox).
-5. [🐺 Librewolf Appimage version](https://librewolf.net/installation/linux/).
-4. [🐺 Librewolf 📦 Flatpak version](https://flathub.org/apps/details/io.gitlab.librewolf-community).
+4. [🐺 Librewolf Appimage version](https://librewolf.net/installation/linux/).
+5. [🐺 Librewolf 📦 Flatpak version](https://flathub.org/apps/details/io.gitlab.librewolf-community).
+6. [🧅 Tor Browser](https://community.torproject.org/onion-services/setup/install/).
+7. [🧅 Tor Browser 📦 Flatpak version](https://flathub.org/apps/details/com.github.micahflee.torbrowser-launcher).
 
 ❗*For best experience we recommend to use theme with Firefox installed with apt package manager.*
 *Other installations have limited support. We also welcome contributions like editing a userChrome,*


### PR DESCRIPTION
In favor of issue #170, now theme installation is supported for:

1. 🧅 Tor Browser;
2. 🧅 Tor Browser (📦 Flatpak).