### PR TITLE
fix: infinite waiting when for tor browser windows will be closed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.librewolf
 
 BROWSER="🧅 Tor Browser";
 BROWSERS+=("${BROWSER}");
-BROWSERS_PROCESS_ID["${BROWSER}"]="pidof \"${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_*/Browser/firefox.real\" || exit 0"
+BROWSERS_PROCESS_ID["${BROWSER}"]="pidof ${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_*/Browser/firefox.real || exit 0"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_*/Browser/TorBrowser/Data/Browser"
 
 FLATPAK_ID="com.github.micahflee.torbrowser-launcher"


### PR DESCRIPTION
One small fix, of waiting Tor Browser windows to be closed before preference patch.
This will affect only Tor Browser installed with apt package manager, not flatpak.

_P.S. Testing is not required, especially when you already have Flatpak version installed. It is almost impossible to have both (flatpak and apt) versions installed at same moment (there is high chance to have problems with installer signature verification)._