### PR TITLE
feat: update option for install.sh script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ bash <(wget --quiet --output-document - "https://raw.githubusercontent.com/Zonne
 ```
 
 Installation script will also patch Firefox preference to enable native titlebar usage.
-Firefox use native titlebar by default, but Elementary Firefox Theme not.
+Firefox doesn't use native titlebar by default.
 
 To force installation of Private Mode Style, use script:
 
@@ -54,3 +54,11 @@ This will make purple colors of Private Mode as default style.
 
 1. In the customization panel in Firefox you can move the new tab button to the left and select System theme. You can also use the dark theme option but light theme is not supported.
 2. If you use [Pantheon Tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks/) with the dark mode on, the theme changes to dark mode by itself. Firefox 98 and newer are changing to dark mode when the elementary OS system dark mode is set.
+
+## Update
+
+To update installed theme, use script
+
+```bash
+bash <(wget --quiet --output-document - "https://raw.githubusercontent.com/Zonnev/elementaryos-firefox-theme/elementaryos-firefox-theme/install.sh") --update
+```

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 # An elementary OS theme for Firefox
 ![Screenshot](theme.png)
 
-## Credits
+## 🙏 Credits
 
 Credits to [Harvey Cabaguio](https://github.com/harveycabaguio/firefox-elementary-theme) for setting the theme up, [Surendrajat](https://github.com/Surendrajat), [DRHAX34](https://github.com/DRHAX34) and [sempasha](https://github.com/sempasha) for the install script and the elementary team for the UI design and icons.
 
-## Install
+## ⬇️ Install
 
 For now theme installation is supported for:
 
@@ -50,12 +50,12 @@ bash <(wget --quiet --output-document - "https://raw.githubusercontent.com/Zonne
 
 This will make purple colors of Private Mode as default style.
 
-## After installation
+## ➕ After installation
 
 1. In the customization panel in Firefox you can move the new tab button to the left and select System theme. You can also use the dark theme option but light theme is not supported.
 2. If you use [Pantheon Tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks/) with the dark mode on, the theme changes to dark mode by itself. Firefox 98 and newer are changing to dark mode when the elementary OS system dark mode is set.
 
-## Update
+## 🔁 Update
 
 To update installed theme, use script
 


### PR DESCRIPTION
Now install.sh has special option to update previously installed theme stylesheets. Update mode will affect only profiles where `chrome/userChrome.css` stylesheet is installed.

Snippet for testing.

```bash
bash <(wget --quiet --output-document - "https://raw.githubusercontent.com/sempasha/elementaryos-firefox-theme/update/install.sh") --update
```