### PR TITLE
Support theme installation for 🦊 firefox (📦 snap)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,11 @@ function getFlatpakProcessIdCommand {
   echo "flatpak ps --columns=pid,application | grep \"${FLATPAK_ID}\" | cut -f1"
 }
 
+function getSnapProcessIdCommand {
+  local PROCESS_NAME="${1}"
+  echo "for pid in \$(pidof ${PROCESS_NAME}); do ps --no-headers \${pid} | grep '/snap/' | awk '{print \$1}'; done"
+}
+
 declare -a BROWSERS
 declare -A BROWSERS_PROCESS_ID
 declare -A BROWSERS_PROFILES_ROOTS
@@ -37,6 +42,11 @@ BROWSER="🦊 Firefox (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.mozilla/firefox"
+
+BROWSER="🦊 Firefox (📦 Snap)";
+BROWSERS+=("${BROWSER}");
+BROWSERS_PROCESS_ID["${BROWSER}"]="$(getSnapProcessIdCommand "firefox")"
+BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/snap/firefox/common/.mozilla/firefox"
 
 BROWSER="🐺 Librewolf";
 BROWSERS+=("${BROWSER}");

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ For now theme installation is supported for:
 2. [🦊 Firefox Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly)
    installed with apt package manager.
 3. [🦊 Firefox 📦 Flatpak version](https://flathub.org/apps/details/org.mozilla.firefox).
+3. [🦊 Firefox 📦 Snap version](https://snapcraft.io/firefox).
 4. [🐺 Librewolf Appimage version](https://librewolf.net/installation/linux/).
 5. [🐺 Librewolf 📦 Flatpak version](https://flathub.org/apps/details/io.gitlab.librewolf-community).
 6. [🧅 Tor Browser](https://community.torproject.org/onion-services/setup/install/).


### PR DESCRIPTION
Pull request resolves issue #189.

@Zonnev, as I said, I haven't access to Elementary OS early builds, so I cannot test installation script properly. I have Firefox snap and theme installation works well with it.

Could you, please, test install.sh with early build. Test script is

```bash
bash <(wget --quiet --output-document - "https://raw.githubusercontent.com/sempasha/elementaryos-firefox-theme/elementaryos-firefox-theme/install.sh")
```