### PR TITLE
Support elementary OS 8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -601,14 +601,11 @@ function installThemeAtBrowserProfile {
         exit 1
       fi
 
-      local GALA_BUTTON_LAYOUT="$(gsettings get org.pantheon.desktop.gala.appearance button-layout)"
       local WM_BUTTON_LAYOUT="$(gsettings get org.gnome.desktop.wm.preferences button-layout)"
       local BUTTON_LAYOUT=""
 
-      if [ ! -z "${GALA_BUTTON_LAYOUT}" ]; then
-        BUTTON_LAYOUT="${GALA_BUTTON_LAYOUT}"
-      elif [ ! -z "${WM_BUTTON_LAYOUT}" ]; then
-        BUTTON_LAYOUT="${GALA_BUTTON_LAYOUT}"
+      if [ ! -z "${WM_BUTTON_LAYOUT}" ]; then
+        BUTTON_LAYOUT="${WM_BUTTON_LAYOUT}"
       fi
 
       if [ ! -z "${BUTTON_LAYOUT}" ]; then


### PR DESCRIPTION
- Remove access to Gala's appearance schema
    - It has never been used in Gala and was removed in https://github.com/elementary/gala/commit/66679ca79662cff3eca5b4d850aeec4bad23bbd4
    - This causes the script to fail on OS 8
- Use correct variable in case of WM_BUTTON_LAYOUT

Tested changing button layout and re-executing the script reflects it to FireFox on latest OS 8 Early Access and latest 7.1