### PR TITLE
Improved install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,11 +233,14 @@ Window controls layout may be changed with Pantheon Tweaks application
 
 Supported window controls layouts are:
 
+$(printf "%3s  %-30s %-28s %s\n" "#" "Layout" "GSettings value" "Schema")
+ -----------------------------------------------------------------------------
 $(
   for INDEX in "${!LAYOUTS[@]}"; do
     LAYOUT="${LAYOUTS[${INDEX}]}"
     TITLEBAR="${LAYOUTS_TITLEBARS[${LAYOUT}]}"
-    printf "%3s. %-30s %s\n" "$((INDEX+1))" "${LAYOUT}" "${TITLEBAR}"
+    SETTING="${LAYOUTS_SETTINGS[${LAYOUT}]}"
+    printf "%3s. %-30s %-28s %s\n" "$((INDEX+1))" "${LAYOUT}" "${SETTING}" "${TITLEBAR}"
   done
 )
 
@@ -686,12 +689,7 @@ function installThemeAtBrowserProfile {
         exit 1
       fi
 
-      local WM_BUTTON_LAYOUT="$(gsettings get org.gnome.desktop.wm.preferences button-layout)"
-      local BUTTON_LAYOUT=""
-
-      if [ ! -z "${WM_BUTTON_LAYOUT}" ]; then
-        BUTTON_LAYOUT="${WM_BUTTON_LAYOUT}"
-      fi
+      local BUTTON_LAYOUT="$(gsettings get org.gnome.desktop.wm.preferences button-layout)"
 
       if [ ! -z "${BUTTON_LAYOUT}" ]; then
         for LAYOUT in "${!LAYOUTS_SETTINGS[@]}"; do
@@ -700,13 +698,22 @@ function installThemeAtBrowserProfile {
             break
           fi
         done
-      fi
-
-      if [ -z "${CONTROLS_LAYOUT}" ]; then
-        error "💥 Unable to detect window controls layout."
-        error "💥 Please, specify layout with '--controls-layout' option."
-        error "❓ Try '${APP_EXECUTABLE} --help' to see manual."
-        exit 1
+        if [ -z "${CONTROLS_LAYOUT}" ]; then
+          error "💥 Unable to detect window controls layout using gsettings."
+          error "💥 gsettings reports current button layout is ${BUTTON_LAYOUT}, "
+          error "💥 and it doesn't match any known button layout."
+          error "💥 Please, specify layout with '--controls-layout' option."
+          error "❓ Try '${APP_EXECUTABLE} --help' to see manual."
+          exit 1
+        fi
+      else
+        if [ -z "${CONTROLS_LAYOUT}" ]; then
+          error "💥 Unable to detect window controls layout using gsettings."
+          error "💥 gsettings reports current button layout is not specified."
+          error "💥 Please, specify layout with '--controls-layout' option."
+          error "❓ Try '${APP_EXECUTABLE} --help' to see manual."
+          exit 1
+        fi
       fi
     fi
   }

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,8 @@ FLATPAK_ID="org.mozilla.firefox"
 BROWSER="🦊 Firefox (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
-BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.mozilla/firefox"
+BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.mozilla/firefox
+${HOME}/.var/app/${FLATPAK_ID}/config/mozilla/firefox"
 
 # Firefox installed from snap package.
 BROWSER="🦊 Firefox (📦 Snap)";

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ GITHUB_BRANCH_NAME="master"
 GITHUB_PROJECT_NAME="Zonnev/elementaryos-firefox-theme"
 GITHUB_URL="https://github.com"
 GITHUB_URL_RAW="https://raw.githubusercontent.com"
+DRY_RUN="no"
 
 function getFlatpakProcessIdCommand {
   local FLATPAK_ID="${1}"
@@ -228,6 +229,16 @@ OPTIONS:
   Example: ${APP_EXECUTABLE} --controls-layout 'Elementary Reversed'
   Example: ${APP_EXECUTABLE} --controls-layout 2
 
+--dry-run
+
+  Execute script in dry-run mode. In dry-run mode script will not create,
+  remove or update any files, will not change any browser settings, just print logs.
+  It is possible to combine --dry-run option with other parameters.
+  This options is useful for installation script testing purposes.
+
+  Example: ${APP_EXECUTABLE} --dry-run
+  Example: ${APP_EXECUTABLE} --dry-run --browser-profile /profile
+
 --github-branch-name <branch>
 
   Overrides theme branch name at ${GITHUB_URL}. Instalation script will copy theme
@@ -392,6 +403,11 @@ function parseOptions {
             shift 2
             ;;
         esac
+        ;;
+
+      "--dry-run")
+        DRY_RUN="yes"
+        shift 1
         ;;
 
       "--github-branch-name")
@@ -573,31 +589,33 @@ function installThemeAtBrowserProfile {
 
     info "📝 Changing preference '${PREFERENCE}' to '${TARGET_VALUE}'"
 
-    if [ ! -z "$(bash -c "${BROWSERS_PROCESS_ID[${BROWSER}]}")" ]; then
-      info "❓ Please, close ${BROWSER} windows to proceed ...."
-      while [ ! -z "$(bash -c "${BROWSERS_PROCESS_ID[${BROWSER}]}")" ]; do
-        sleep 1
-      done
+    if [ "${DRY_RUN}" == "no" ]; then
+      if [ ! -z "$(bash -c "${BROWSERS_PROCESS_ID[${BROWSER}]}")" ]; then
+        info "❓ Please, close ${BROWSER} windows to proceed ...."
+        while [ ! -z "$(bash -c "${BROWSERS_PROCESS_ID[${BROWSER}]}")" ]; do
+          sleep 1
+        done
+      fi
+
+      increaseLogPadding
+
+      local LINE_NUMBER=""
+
+      if [ -f "${PREFERENCES_FILE}" ]; then
+        LINE_NUMBER=$(grep -n "user_pref(\"${PREFERENCE}\"," "${PREFERENCES_FILE}" | cut -d':' -f1)
+      fi
+
+      if [ -z "${LINE_NUMBER}" ]; then
+        echo "user_pref(\"${PREFERENCE}\", ${TARGET_VALUE});" >> "${PREFERENCES_FILE}"
+      else
+        sed -i "${LINE_NUMBER}s/.*/user_pref(\"${PREFERENCE}\", "${TARGET_VALUE}");/" "${PREFERENCES_FILE}"
+      fi
+
+      decreaseLogPadding
     fi
-
-    increaseLogPadding
-
-    local LINE_NUMBER=""
-
-    if [ -f "${PREFERENCES_FILE}" ]; then
-      LINE_NUMBER=$(grep -n "user_pref(\"${PREFERENCE}\"," "${PREFERENCES_FILE}" | cut -d':' -f1)
-    fi
-
-    if [ -z "${LINE_NUMBER}" ]; then
-      echo "user_pref(\"${PREFERENCE}\", ${TARGET_VALUE});" >> "${PREFERENCES_FILE}"
-    else
-      sed -i "${LINE_NUMBER}s/.*/user_pref(\"${PREFERENCE}\", "${TARGET_VALUE}");/" "${PREFERENCES_FILE}"
-    fi
-
-    decreaseLogPadding
   }
 
-  function delectControlsLayout {
+  function detectControlsLayout {
     if [ -z "${CONTROLS_LAYOUT}" ]; then
       if ! (which gsettings >/dev/null); then
         error "💥 Unable to detect window controls layout. Util gsettings is not installed."
@@ -763,25 +781,37 @@ function installThemeAtBrowserProfile {
 
     if [ ! -d ${CHROME_DIR} ]; then
       info "✅ Creating 📁 $(replaceHomedir "${CHROME_DIR}")"
-      mkdir -p "${CHROME_DIR}"
+      if [ "${DRY_RUN}" == "no" ]; then
+        mkdir -p "${CHROME_DIR}"
+      fi
     fi
 
     info "⬇️  Downloading ${BASE_CSS} (${BASE_URL})"
-    wget --output-document="${BASE_FILE}" --quiet "${BASE_URL}"
+    if [ "${DRY_RUN}" == "no" ]; then
+      wget --output-document="${BASE_FILE}" --quiet "${BASE_URL}"
+    fi
 
     if [[ "${BROWSER}" == *"(📦 Flatpak)" ]] || [[ "${BROWSER}" == *"(📦 Snap)" ]]; then
       info "⬇️  Downloading ${FLATPAK_CSS} (${FLATPAK_URL})"
-      wget --output-document="${FLATPAK_FILE}" --quiet "${FLATPAK_URL}"
+      if [ "${DRY_RUN}" == "no" ]; then
+        wget --output-document="${FLATPAK_FILE}" --quiet "${FLATPAK_URL}"
+      fi
     elif [ -f "${FLATPAK_FILE}" ]; then
       info "🗑️  Removing ${FLATPAK_CSS} (${FLATPAK_FILE})"
-      rm "${FLATPAK_FILE}"
+      if [ "${DRY_RUN}" == "no" ]; then
+        rm "${FLATPAK_FILE}"
+      fi
     fi
 
     info "⬇️  Downloading ${USER_CHROME_CSS} (${USER_CHROME_URL})"
-    wget --output-document="${USER_CHROME_FILE}" --quiet "${USER_CHROME_URL}"
+    if [ "${DRY_RUN}" == "no" ]; then
+      wget --output-document="${USER_CHROME_FILE}" --quiet "${USER_CHROME_URL}"
+    fi
 
     info "⬇️  Downloading ${USER_CONTENT_CSS} (${USER_CONTENT_URL})"
-    wget --output-document="${USER_CONTENT_FILE}" --quiet "${USER_CONTENT_URL}"
+    if [ "${DRY_RUN}" == "no" ]; then
+      wget --output-document="${USER_CONTENT_FILE}" --quiet "${USER_CONTENT_URL}"
+    fi
   }
 
   local BROWSER_PROFILE="${1}"
@@ -802,7 +832,7 @@ function installThemeAtBrowserProfile {
   elif [ $(getBrowserNativeTitlebarEnabled "${BROWSER_PROFILE}") == "yes" ]; then
     installStyleSheets "${BROWSER}" "${BROWSER_PROFILE}" "${TITLEBAR_ENABLED_PATH}"
   else
-    delectControlsLayout
+    detectControlsLayout
     installStyleSheets "${BROWSER}" "${BROWSER_PROFILE}" "${LAYOUTS_PATHS[${CONTROLS_LAYOUT}]}"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,25 @@
 
 set -e
 
-GITHUB_BRANCH_NAME="master"
-GITHUB_PROJECT_NAME="Zonnev/elementaryos-firefox-theme"
-GITHUB_URL="https://github.com"
-GITHUB_URL_RAW="https://raw.githubusercontent.com"
+# Defines execution mode, to use dry-run or not.
+# Variable is controlled by --dry-run script option.
 DRY_RUN="no"
+
+# Represents git branch, which will be used during theme installation.
+# Variable is controlled by --github-branch-name script option.
+GITHUB_BRANCH_NAME="master"
+
+# Represents github project page (user/project), which will be used during theme installation.
+# Variable is controlled by --github-project-name script option.
+GITHUB_PROJECT_NAME="Zonnev/elementaryos-firefox-theme"
+
+# Represents github base url, which will be used during theme installation.
+# This is constant, there is no script option to change the value.
+GITHUB_URL="https://github.com"
+
+# Represents github base url for obtaining raw files, it will be used during theme installation.
+# This is constant, there is no script option to change the value.
+GITHUB_URL_RAW="https://raw.githubusercontent.com"
 
 function getFlatpakProcessIdCommand {
   local FLATPAK_ID="${1}"
@@ -22,63 +36,102 @@ function getSnapProcessIdCommand {
   echo "for pid in \$(pidof ${PROCESS_NAME}); do ps --no-headers \${pid} | grep '/snap/' | awk '{print \$1}'; done"
 }
 
+# Plain array where each record represents a browser name.
 declare -a BROWSERS
+
+# Associative array where:
+# - Key refers to a browser name (see BROWSERS).
+# - Value represents a command which may be used to obtain running browser processes identifiers (PIDs).
 declare -A BROWSERS_PROCESS_ID
+
+# Associative array where:
+# - Key refers to a browser name (see BROWSERS).
+# - Value represents a directory where user profiles stored.
+#   Several directories may be specified, each line is a directory.
+#   For example:
+#   BROWSERS_PROFILES_ROOTS["${BROWSER}"]="first_directory
+#   second_directory
+#   third_directory"
 declare -A BROWSERS_PROFILES_ROOTS
 
+# Default browser name, which will be used in help message.
 DEFAULT_BROWSER="🦊 Firefox"
 
+# Firefox installed from system package (deb, dnf, aur and so on).
 BROWSER="${DEFAULT_BROWSER}";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "firefox" || exit 0'
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.mozilla/firefox"
 
+# Firefox Nightly installed from system package (deb, dnf, aur and so on).
 BROWSER="🦊 Firefox Nightly";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "firefox-trunk" || exit 0'
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.mozilla/firefox-trunk"
 
+# Firefox ESR installed from system package (deb, dnf, aur and so on).
 BROWSER="🦊 Firefox ESR";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "firefox-esr" || exit 0'
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.mozilla/firefox-esr"
 
+# Firefox installed from flatpak package.
 FLATPAK_ID="org.mozilla.firefox"
 BROWSER="🦊 Firefox (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.mozilla/firefox"
 
+# Firefox installed from snap package.
 BROWSER="🦊 Firefox (📦 Snap)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="$(getSnapProcessIdCommand "firefox")"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/snap/firefox/common/.mozilla/firefox"
 
+# Librewolf installed from system package (deb, dnf, aur and so on).
 BROWSER="🐺 Librewolf";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]='pidof "librewolf" || exit 0'
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.librewolf"
 
+# Librewolf installed from flatpak package.
 FLATPAK_ID="io.gitlab.librewolf-community"
 BROWSER="🐺 Librewolf (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="$(getFlatpakProcessIdCommand "${FLATPAK_ID}")"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/.librewolf"
 
+# Tor Browser installed from system package (deb, dnf, aur and so on).
 BROWSER="🧅 Tor Browser";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="pidof ${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_*/Browser/firefox.real || exit 0"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_*/Browser/TorBrowser/Data/Browser"
 
+# Tor Browser installed from flatpak package.
 FLATPAK_ID="com.github.micahflee.torbrowser-launcher"
 BROWSER="🧅 Tor Browser (📦 Flatpak)";
 BROWSERS+=("${BROWSER}");
 BROWSERS_PROCESS_ID["${BROWSER}"]="pidof ${HOME}/.var/app/${FLATPAK_ID}/data/torbrowser/tbb/x86_64/tor-browser_*/Browser/firefox.real || exit 0"
 BROWSERS_PROFILES_ROOTS["${BROWSER}"]="${HOME}/.var/app/${FLATPAK_ID}/data/torbrowser/tbb/x86_64/tor-browser_*/Browser/TorBrowser/Data/Browser"
 
+# Plain array where record represents layout name
 declare -a LAYOUTS
+
+# Associative array where:
+# - Key refers to a layout name;
+# - Value represents github directory (url encoded) where layout specific style-sheet is stored.
 declare -A LAYOUTS_PATHS
+
+# Associative array where:
+# - Key refers to a layout name;
+# - Value represents a value of 'button-layout' key of 'org.gnome.desktop.wm.preferences' schema
+#   which corresponds to named layout. For example 'close:maximize' corresponds to an Elementary layout
+#   (single close button on left side and single maximize-minimize button on right side).
 declare -A LAYOUTS_SETTINGS
+
+# Associative array where:
+# - Key refers to a layout name;
+# - Value represents a schematic layout representation which will be used to print script's help message.
 declare -A LAYOUTS_TITLEBARS
 
 LAYOUT="Elementary"
@@ -141,11 +194,19 @@ LAYOUTS_PATHS["${LAYOUT}"]="Replace%20Maximize%20to%20Minimize"
 LAYOUTS_SETTINGS["${LAYOUT}"]="'close:minimize'"
 LAYOUTS_TITLEBARS["${LAYOUT}"]="[⨯    —    ⤓]"
 
+# Github directory (url encoded) where private mode layout is stored.
 PRIVATE_MODE_PATH="Private%20Mode%20Style"
+
+# Github directory (url encoded) where titlebar enabled mode layout is stored.
 TITLEBAR_ENABLED_PATH="Titlebar%20Enabled"
 
+# Name of script executable which will be used to print script's help message and error reports.
 APP_EXECUTABLE="install.sh"
+
+# Script name which will be used to print script's help message.
 APP_NAME="🦊 Firefox Elementary Theme installation"
+
+# Script's help message
 APP_HELP_MESSAGE="Installation script is recommended to install 🦊 Firefox Elementary Theme.
 
 Theme is set of stylesheets ('userChrome.css' and 'userContent.css'). To apply


### PR DESCRIPTION
New features:

* 🧪 Dry Run mode, use install.sh --dry-run to see what script will do without changing anything, useful for script testing;
* 📁 New profiles directory `~/.var/app/org.mozilla.firefox/config/mozilla/firefox` supported for 🦊 Firefox (📦 Flatpak), see #214.

Other improvements:

* 💄 Improved install script output during detecting controls layout, now script show button layout used by gsettings, and show current user's button layout detected by reading gsettings schema keys;
* 🌻 Script's variables commented to explain their purpose.